### PR TITLE
Fixing a length check

### DIFF
--- a/src/main/java/org/jboss/aerogear/crypto/Util.java
+++ b/src/main/java/org/jboss/aerogear/crypto/Util.java
@@ -32,7 +32,7 @@ public class Util {
     }
 
     public static byte[] checkLength(byte[] data, int size) {
-        if (data == null || data.length != size)
+        if (data == null || data.length < size)
             throw new RuntimeException("Invalid length: " + data.length);
         return data;
     }

--- a/src/test/java/org/jboss/aerogear/crypto/UtilTest.java
+++ b/src/test/java/org/jboss/aerogear/crypto/UtilTest.java
@@ -31,6 +31,8 @@ public class UtilTest {
         try {
             byte[] data = new byte[32];
             checkLength(data, MINIMUM_SECRET_KEY_SIZE);
+            data = new byte[64];
+            checkLength(data, MINIMUM_SECRET_KEY_SIZE);
         } catch (Exception e) {
             fail("Should not raise any exception");
         }


### PR DESCRIPTION
Shouldn't check length ensure a minimum length instead of an exact length?
