### PR TITLE
The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/jboss/aerogear/AeroGearCrypto.java
+++ b/src/main/java/org/jboss/aerogear/AeroGearCrypto.java
@@ -31,17 +31,6 @@ import java.security.Security;
 public class AeroGearCrypto {
 
     public static final String PROVIDER = Util.isAndroid() ? "SC" : "BC";
-
-    private AeroGearCrypto() {
-    }
-
-    static {
-        if (Security.getProvider(PROVIDER) == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
-
-    }
-
     //PBKDF2
     public static final String PBKDF2_ALGORITHM = "PBKDF2WithHmacSHA1";
     public static final int DERIVED_KEY_LENGTH = 256;
@@ -65,6 +54,15 @@ public class AeroGearCrypto {
     //Default SHA
     public static final String DEFAULT_SHA_ALGORITHM = "SHA-256";
 
+    private AeroGearCrypto() {
+    }
+
+    static {
+        if (Security.getProvider(PROVIDER) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+
+    }
 
     public static Pbkdf2 pbkdf2() {
         try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
Ayman Abdelghany.
